### PR TITLE
Issue #5: Setting "sourceName" to "Devon4Net" in template.json should…

### DIFF
--- a/Templates/OASP4NetAPI/nuget/content/.template.config/template.json
+++ b/Templates/OASP4NetAPI/nuget/content/.template.config/template.json
@@ -1,6 +1,6 @@
 ﻿{
   "author": "Capgemini Valencia ",
-  "classifications": ["OASP", "Devon4Net"],
+  "classifications": [ "OASP", "Devon4Net" ],
   "description": "Devon4Net API solution template",
   "name": "Devon4Net API solution template",
   "identity": "Devon4Net.WebAPI",
@@ -10,6 +10,7 @@
     "type": "solution"
   },
   "shortName": "Devon4NetAPI",
-  "sourceName": "Devon4NetAPI",
+  "sourceName": "Devon4Net",
+  "preferNameDirectory": true,
   "guids": []
 }


### PR DESCRIPTION
Setting "sourceName" to "Devon4Net" in template.json should fix the issue.
Was however not able to test the fix due to challenges to create the nuget package and once the new package was available, unable to get the new template properly registered with dotnet new.