### PR TITLE
Fixed issue with CORS component when using HTTP protocol

### DIFF
--- a/source/Modules/Devon4Net.Infrastructure.Cors/CorsConfiguration.cs
+++ b/source/Modules/Devon4Net.Infrastructure.Cors/CorsConfiguration.cs
@@ -31,7 +31,11 @@ namespace Devon4Net.Application.WebAPI.Configuration
 
         public static void SetupCors(this IApplicationBuilder builder)
         {
-            if (CorsOptions == null || CorsOptions.Count == 0) return;
+            if (CorsOptions == null || CorsOptions.Count == 0)
+            {
+                builder.UseCors("CorsPolicy");
+                return;
+            }
 
             foreach (var policy in CorsOptions.Select(c => c.CorsPolicy))
             {


### PR DESCRIPTION
Added default policy to CORS middleware when no options are specified in 'appsettings.{environment}.json' file